### PR TITLE
removed /lambda in the names of Lambda zip files

### DIFF
--- a/templates/quickstart-connect-voci-base-pipeline.yaml
+++ b/templates/quickstart-connect-voci-base-pipeline.yaml
@@ -83,15 +83,15 @@ Resources:
         QSS3KeyPrefix: !Ref 'QSS3KeyPrefix'
         LambdaZipObjects: !Join
           - ','
-          - - functions/packages/CheckElasticsearchStatus/lambda.zip
-            - functions/packages/CheckTranscriptionJob/lambda.zip
-            - functions/packages/ElasticsearchCognito/lambda.zip
-            - functions/packages/IndexCTRInElasticSearch/lambda.zip
-            - functions/packages/IndexS3TranscriptionDataIntoES/lambda.zip
-            - functions/packages/ProcessTranscription/lambda.zip
-            - functions/packages/S3ProcessNewAudio/lambda.zip
-            - functions/packages/StartTranscriptionJob/lambda.zip
-            - functions/packages/CWLToElasticSearchLambda/lambda.zip
+          - - functions/packages/CheckElasticsearchStatus.zip
+            - functions/packages/CheckTranscriptionJob.zip
+            - functions/packages/ElasticsearchCognito.zip
+            - functions/packages/IndexCTRInElasticSearch.zip
+            - functions/packages/IndexS3TranscriptionDataIntoES.zip
+            - functions/packages/ProcessTranscription.zip
+            - functions/packages/S3ProcessNewAudio.zip
+            - functions/packages/StartTranscriptionJob.zip
+            - functions/packages/CWLToElasticSearchLambda.zip
     # End Lambda Portability stack
   #**********************************
   CognitoStack:
@@ -174,7 +174,7 @@ Resources:
     Properties:
       CodeUri:
         Bucket: !GetAtt LPStack.Outputs.LambdaZipsBucketName
-        Key: !Sub '${QSS3KeyPrefix}functions/packages/ElasticsearchCognito/lambda.zip'
+        Key: !Sub '${QSS3KeyPrefix}functions/packages/ElasticsearchCognito.zip'
       Description: ''
       Environment:
         Variables:
@@ -191,7 +191,7 @@ Resources:
     Properties:
       CodeUri:
         Bucket: !GetAtt LPStack.Outputs.LambdaZipsBucketName
-        Key: !Sub '${QSS3KeyPrefix}functions/packages/CheckElasticsearchStatus/lambda.zip'
+        Key: !Sub '${QSS3KeyPrefix}functions/packages/CheckElasticsearchStatus.zip'
       Description: ''
       Handler: elasticsearch-cognito.check_status
       MemorySize: 128
@@ -204,7 +204,7 @@ Resources:
     Properties:
       CodeUri:
         Bucket: !GetAtt LPStack.Outputs.LambdaZipsBucketName
-        Key: !Sub '${QSS3KeyPrefix}functions/packages/IndexS3TranscriptionDataIntoES/lambda.zip'
+        Key: !Sub '${QSS3KeyPrefix}functions/packages/IndexS3TranscriptionDataIntoES.zip'
       Description: 'Lambda function that indexes the Transcription and NLP entities/keyphrases'
       Environment:
         Variables:
@@ -222,7 +222,7 @@ Resources:
     Properties:
       CodeUri:
         Bucket: !GetAtt LPStack.Outputs.LambdaZipsBucketName
-        Key: !Sub '${QSS3KeyPrefix}functions/packages/StartTranscriptionJob/lambda.zip'
+        Key: !Sub '${QSS3KeyPrefix}functions/packages/StartTranscriptionJob.zip'
       Description: 'Lambda function that starts the Transcription job'
       Handler: start_transcription.lambda_handler
       MemorySize: 256
@@ -235,7 +235,7 @@ Resources:
     Properties:
       CodeUri:
         Bucket: !GetAtt LPStack.Outputs.LambdaZipsBucketName
-        Key: !Sub '${QSS3KeyPrefix}functions/packages/CheckTranscriptionJob/lambda.zip'
+        Key: !Sub '${QSS3KeyPrefix}functions/packages/CheckTranscriptionJob.zip'
       Description: 'Lambda function that checks the status of the Transcription job'
       Handler: check_transcribe.lambda_handler
       MemorySize: 256
@@ -248,7 +248,7 @@ Resources:
     Properties:
       CodeUri:
         Bucket: !GetAtt LPStack.Outputs.LambdaZipsBucketName
-        Key: !Sub '${QSS3KeyPrefix}functions/packages/ProcessTranscription/lambda.zip'
+        Key: !Sub '${QSS3KeyPrefix}functions/packages/ProcessTranscription.zip'
       Description: 'Lambda function that processes the Transcription job'
       Environment:
         Variables:
@@ -265,7 +265,7 @@ Resources:
     Properties:
       CodeUri:
         Bucket: !GetAtt LPStack.Outputs.LambdaZipsBucketName
-        Key: !Sub '${QSS3KeyPrefix}functions/packages/IndexCTRInElasticSearch/lambda.zip'
+        Key: !Sub '${QSS3KeyPrefix}functions/packages/IndexCTRInElasticSearch.zip'
       Description: 'Lambda function that indexes the CTR into Elastic Search'
       Environment:
         Variables:
@@ -290,7 +290,7 @@ Resources:
     Properties:
       CodeUri:
         Bucket: !GetAtt LPStack.Outputs.LambdaZipsBucketName
-        Key: !Sub '${QSS3KeyPrefix}functions/packages/S3ProcessNewAudio/lambda.zip'
+        Key: !Sub '${QSS3KeyPrefix}functions/packages/S3ProcessNewAudio.zip'
       Description: 'Lambda function that starts the step function'
       Environment:
         Variables:
@@ -447,7 +447,7 @@ Resources:
     Properties:
       CodeUri:
         Bucket: !GetAtt LPStack.Outputs.LambdaZipsBucketName
-        Key: !Sub '${QSS3KeyPrefix}functions/packages/CWLToElasticSearchLambda/lambda.zip'
+        Key: !Sub '${QSS3KeyPrefix}functions/packages/CWLToElasticSearchLambda.zip'
       Description: Contact flow Cloudwatch logs to Amazon Elasticsearch and S3
       Environment:
         Variables:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I followed the Directions in setting up this integration. However, it seems that Cloudformation runs into an error for the resource LPStack.

Embedded stack [STACK_ARN] was not successfully created: The following resource(s) failed to create: [CopyZips].

In the Lambda log stream that was specified it seems we are trying to copy from a source that does not exist:

key = top-level/functions/packages/CheckElasticsearchStatus/lambda.zip
[ERROR]	2020-06-05T00:08:05.677Z	5a8e6649-bc20-40d6-9b9e-71cf52775c3f	Exception: An error occurred (AccessDenied) when calling the CopyObject operation: Access Denied

When we run ./build.sh the actual file that is created is top-level/functions/packages/CheckElasticsearchStatus.zip

I had to change the filenames in the yaml for this to work. That said, please let me know if I may have made any mistakes on my end.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
